### PR TITLE
Ofp improvements

### DIFF
--- a/src/jetfuelburn/utility/ofp.py
+++ b/src/jetfuelburn/utility/ofp.py
@@ -244,8 +244,14 @@ def generate_4d_trajectory(
     Notes
     -----
     The function implements a `leveloff` strategy by default:
-    If the aircraft reaches the altitude of the next waypoint before arriving at the waypoint's
-    target time (or distance), it will level off at that target altitude until the waypoint is reached.
+
+    - **Climb**: the aircraft begins climbing immediately and levels off at the target altitude,
+      holding it until the waypoint is reached.
+    - **Descent**: the aircraft holds its current altitude for as long as possible, then begins
+      descending at the applicable rate so as to arrive at the target altitude exactly at the
+      next waypoint (Top of Descent / TOD back-calculation). The TOD is estimated using the
+      descent rate at the current altitude; as the aircraft descends through multiple regimes
+      the rate is re-evaluated at each time step.
 
     ![Flight Plan Diagram](../_static/ofp_1.svg)
 
@@ -365,17 +371,20 @@ def generate_4d_trajectory(
                         curr_alt += r_val * (step_s / 60.0)
                         if curr_alt > leveloff_target:
                             curr_alt = leveloff_target
-                    else:  # descent
+                    else:  # descent: hold altitude until TOD, then descend
                         rate = _get_aircraft_performance(
                             perf_data_path=perf_data_path,
                             aircraft_type=aircraft_type,
                             phase="descent",
                             alt=curr_alt * ureg(unit_alt),
                         )
-                        r_val = rate.to(f"{unit_alt}/min").magnitude
-                        curr_alt += r_val * (step_s / 60.0)
-                        if curr_alt < leveloff_target:
-                            curr_alt = leveloff_target
+                        r_val = rate.to(f"{unit_alt}/min").magnitude  # negative
+                        alt_to_lose = curr_alt - leveloff_target
+                        time_needed_s = (alt_to_lose / abs(r_val)) * 60.0
+                        if rem_s <= time_needed_s:
+                            curr_alt += r_val * (step_s / 60.0)
+                            if curr_alt < leveloff_target:
+                                curr_alt = leveloff_target
 
             curr_t += pd.Timedelta(seconds=step_s)
             if duration_s > 0:

--- a/tests/test_ofp.py
+++ b/tests/test_ofp.py
@@ -405,3 +405,37 @@ class TestGenerate4DTrajectory:
         )
         assert isinstance(result, pd.DataFrame)
         assert len(result) > 0
+
+    # --- descent / TOD behavior --------------------------------------------
+
+    def test_tod_no_premature_ground_level(self, tmp_yaml):
+        """
+        With TOD strategy, the aircraft must hold cruise altitude at the start
+        of a descent segment rather than descending immediately.
+
+        Setup
+        -----
+        - DEP: 35000 ft, t=0 min
+        - MID: DSC,      t=60 min
+        - ARR: 0 ft,     t=120 min
+
+        ROD in the 5000–35000 ft band = 1000 ft/min → 35 min needed to descend
+        from 35000 to 0 ft. TOD should therefore occur around t=25 min, meaning
+        the aircraft must still be at 35000 ft at t=10 min.
+        The old (buggy) behaviour would already be at 25000 ft by t=10 min.
+        """
+        df = pd.DataFrame({
+            "waypoint": ["DEP", "MID", "ARR"],
+            "alt": [35000, "DSC", 0],
+            "timecum": [0, 60, 120],
+            "lat": [47.0, 47.5, 48.0],
+            "lon": [8.0, 8.5, 9.0],
+        })
+        result = generate_4d_trajectory(df, "TEST", tmp_yaml, time_resolution=1 * ureg.minute)
+        # At t=10 min the aircraft should still be at cruise altitude (TOD not yet reached)
+        ts_check = pd.Timestamp("2025-01-01 00:10:00")
+        row = result[result["timestamp"] == ts_check]
+        assert len(row) > 0, "Expected a row at t=10 min"
+        assert row["alt_filled"].iloc[0] > 30000, (
+            "Aircraft should still be near cruise altitude at t=10 min (TOD not yet reached)"
+        )

--- a/tests/test_ofp.py
+++ b/tests/test_ofp.py
@@ -424,18 +424,22 @@ class TestGenerate4DTrajectory:
         the aircraft must still be at 35000 ft at t=10 min.
         The old (buggy) behaviour would already be at 25000 ft by t=10 min.
         """
-        df = pd.DataFrame({
-            "waypoint": ["DEP", "MID", "ARR"],
-            "alt": [35000, "DSC", 0],
-            "timecum": [0, 60, 120],
-            "lat": [47.0, 47.5, 48.0],
-            "lon": [8.0, 8.5, 9.0],
-        })
-        result = generate_4d_trajectory(df, "TEST", tmp_yaml, time_resolution=1 * ureg.minute)
+        df = pd.DataFrame(
+            {
+                "waypoint": ["DEP", "MID", "ARR"],
+                "alt": [35000, "DSC", 0],
+                "timecum": [0, 60, 120],
+                "lat": [47.0, 47.5, 48.0],
+                "lon": [8.0, 8.5, 9.0],
+            }
+        )
+        result = generate_4d_trajectory(
+            df, "TEST", tmp_yaml, time_resolution=1 * ureg.minute
+        )
         # At t=10 min the aircraft should still be at cruise altitude (TOD not yet reached)
         ts_check = pd.Timestamp("2025-01-01 00:10:00")
         row = result[result["timestamp"] == ts_check]
         assert len(row) > 0, "Expected a row at t=10 min"
-        assert row["alt_filled"].iloc[0] > 30000, (
-            "Aircraft should still be near cruise altitude at t=10 min (TOD not yet reached)"
-        )
+        assert (
+            row["alt_filled"].iloc[0] > 30000
+        ), "Aircraft should still be near cruise altitude at t=10 min (TOD not yet reached)"


### PR DESCRIPTION
I updated the OFP trajectory generation logic in the descent phase. Previously there was the problem of the aircraft reaching ground level / 0 ft too early, before the arrival airport.

...this was originally requested in the issue #68 Improve "Level-Off" Logic