### PR TITLE
Fix homepage Plotly figure disappearing under instant navigation

### DIFF
--- a/docs/_javascripts/plotly.js
+++ b/docs/_javascripts/plotly.js
@@ -1,0 +1,9 @@
+// Renders Plotly figures emitted by markdown-exec blocks as inert JSON in a
+// data attribute. Inline <script> tags in page content are unreliable under
+// instant navigation, so figures are drawn from here on every page load.
+document$.subscribe(function() {
+  document.querySelectorAll("div.plotly-figure").forEach(function(el) {
+    var spec = JSON.parse(el.dataset.fig)
+    Plotly.newPlot(el.querySelector("div.plotly-figure-target"), spec.data, spec.layout, { responsive: true })
+  })
+})

--- a/docs/_requirements.txt
+++ b/docs/_requirements.txt
@@ -5,6 +5,8 @@ ruff
 pymdown-extensions
 markdown-exec[ansi]>=1.12.3
 # requirements for interactive figures
-plotly-express
+# plotly 6.9.0 bundles plotly.js 3.7.0 — keep in sync with the jsDelivr
+# URL in mkdocs.yaml (extra_javascript) when bumping
+plotly==6.9.0
 pandas
 jetfuelburn

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,12 @@ fig.add_layout_image(
     )
 )
 
-print(fig.to_html(full_html=False, include_plotlyjs="cdn"))
-# https://pawamoy.github.io/markdown-exec/gallery/#with-plotly
+# Emit the figure as an inert JSON data attribute; _javascripts/plotly.js
+# draws it on every page load. Inline <script> output (fig.to_html) breaks
+# under instant navigation: Zensical re-executes content scripts on page
+# swap, but inline scripts run before the plotly.js CDN script has loaded,
+# and attributes (e.g. type="application/json") are stripped from clones.
+import html
+print(f'<div class="plotly-figure" data-fig="{html.escape(fig.to_json())}"><div class="plotly-figure-target"></div></div>')
 ```
 _Interactive visualization of fuel burn for different Airbus and Boeing aircraft types, based on 2018 statistical data provided by the U.S. Department of Transportation ([`jetfuelburn.statistics.usdot`][])._

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -94,8 +94,10 @@ extra_javascript:
   - https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.16.9/contrib/auto-render.min.js
   - https://cdnjs.cloudflare.com/ajax/libs/tablesort/5.2.1/tablesort.min.js
   - _javascripts/tablesort.js
-  # version must match the plotly python package used at build time
-  - https://cdn.plot.ly/plotly-3.7.0.min.js
+  # version must match the plotly python package used at build time;
+  # loaded from jsDelivr because plotly's own CDN (cdn.plot.ly) does not
+  # serve the 3.7.x line (HTTP 403)
+  - https://cdn.jsdelivr.net/npm/plotly.js-dist-min@3.7.0/plotly.min.js
   - _javascripts/plotly.js
 extra_css:
   # https://cdnjs.com/libraries/KaTeX

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -94,6 +94,9 @@ extra_javascript:
   - https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.16.9/contrib/auto-render.min.js
   - https://cdnjs.cloudflare.com/ajax/libs/tablesort/5.2.1/tablesort.min.js
   - _javascripts/tablesort.js
+  # version must match the plotly python package used at build time
+  - https://cdn.plot.ly/plotly-3.7.0.min.js
+  - _javascripts/plotly.js
 extra_css:
   # https://cdnjs.com/libraries/KaTeX
   # unpkg is incredibly slow (17s to load the css file)


### PR DESCRIPTION
Fixes two independent problems with the interactive Plotly figure on the homepage. Together they explain both reported symptoms: the figure missing after in-site navigation, and (as of plotly.py 3.7) missing even on hard page loads.

### Problem 1: dead CDN URL (breaks hard loads)
plotly's own CDN does not serve the 3.7.x line: `https://cdn.plot.ly/plotly-3.7.0.min.js` returns HTTP 403 (S3 access denied), while 3.6.0 and older resolve fine. The inline script emitted by `fig.to_html(include_plotlyjs="cdn")` references exactly that URL, so `Plotly` never loads and the figure is missing on every page load of the deployed site. Fixed by loading plotly.js from jsDelivr (`plotly.js-dist-min@3.7.0`, version pinned to match the `plotly` Python package).

### Problem 2: instant navigation drops inline scripts (breaks SPA navigation)
Zensical re-executes scripts found in page content after an instant-navigation page swap, but re-injected inline scripts run before re-injected external scripts have loaded, so the inline `Plotly.newPlot(...)` executes before the plotly.js library is available (`ReferenceError: Plotly is not defined`). Re-injected inline scripts also lose their attributes, which rules out `<script type="application/json">` data payloads as a workaround. Will be reported upstream to zensical/ui.

### Fix
Use the pattern Zensical officially documents for third-party libraries, already used by this repo for KaTeX and tablesort:
- the markdown-exec block emits the figure as an HTML-escaped JSON `data-fig` attribute (inert under all navigation modes)
- `plotly.js` is loaded once via `extra_javascript` from jsDelivr
- a new `docs/_javascripts/plotly.js` draws the figure inside `document$.subscribe()`, which fires on hard loads and after every instant navigation

### Verification
Built both the old and fixed versions and drove them with headless Chromium through both scenarios (hard load, and instant navigation from another page, with the SPA path verified via a `window` marker); the fixed version was additionally verified over the real network against jsDelivr:

| | hard load | instant navigation |
|---|---|---|
| old | figure renders* | missing, `Plotly is not defined` |
| fixed | figure renders | figure renders, no console errors |

*with a reachable plotly.js; on the live site hard loads are broken too because of Problem 1.


Additionally, `plotly` is now pinned in `docs/_requirements.txt` (replacing the deprecated `plotly-express` stub): plotly.py 6.9.0 bundles plotly.js 3.7.0, so the pip package and the jsDelivr URL move together deliberately.