### PR TITLE
Fix broken docstring images and file links on the deployed site

### DIFF
--- a/src/jetfuelburn/diagrams.py
+++ b/src/jetfuelburn/diagrams.py
@@ -29,7 +29,7 @@ def calculate_fuel_consumption_payload_range(
 
     This function implements the simple _"reading fuel mass off the payload/range diagram directly"_ method:
 
-    ![Payload/Range Diagram](../_static/payload_range_generic.svg)
+    <img alt="Payload/Range Diagram" src="../_static/payload_range_generic.svg">
     Payload/Range diagram of the Airbus A350-900 (data derived [from manufacturer information](https://web.archive.org/web/20211129144142/https://www.airbus.com/sites/g/files/jlcbta136/files/2021-11/Airbus-Commercial-Aircraft-AC-A350-900-1000.pdf)).
     Note that in this figure, the y-axis shows _total_ aircraft weight, not _payload weight_.
     Total aircraft weight can be computed by adding the operating empty weight (OEW) to the payload weight and fuel weight.

--- a/src/jetfuelburn/reducedorder.py
+++ b/src/jetfuelburn/reducedorder.py
@@ -11,7 +11,7 @@ class montlaur_etal:
     r"""
     This class implements the reduced-order fuel burn model of Montlaur et al. (2025):
 
-    ![Montlaur et al. Visual Abstract](../_static/reduced_order_montlaur_etal.svg)
+    <img alt="Montlaur et al. Visual Abstract" src="../_static/reduced_order_montlaur_etal.svg">
 
     In this model, fuel burn calculations are based on a regression model.
     The regression coefficients were obtained by fitting mission parameters to fuel burn data obtained
@@ -169,7 +169,7 @@ class sacchi_etal:
     r"""
     This class implements the reduced-order fuel burn model of Sacchi et al. (2023):
 
-    ![Sacchi et al. Visual Abstract](../_static/reduced_order_sacchi.svg)
+    <img alt="Sacchi et al. Visual Abstract" src="../_static/reduced_order_sacchi.svg">
 
     In this model, fuel burn calculations are based on a weight-based power law.
     The regression coefficients were obtained by fitting mission parameters to fuel burn data obtained
@@ -221,7 +221,7 @@ class sacchi_etal:
     | $r_{fut}$      | [dimensionless]   | Projected future annual improvement rate (post-2018)                   |
     | $t$            | [time]            | Scenario year (>=2018)                                                 |
 
-    ![Annual Improvement Plot](../_static/reduced_order_sacchi_improvement.svg)
+    <img alt="Annual Improvement Plot" src="../_static/reduced_order_sacchi_improvement.svg">
 
     Operating empty weight (OEW) is calculated as a function of maximum passenger capacity:
 
@@ -229,7 +229,7 @@ class sacchi_etal:
     OEW = \left(0.0927 \cdot pax_{max}^2 + 253.6 \cdot pax_{max} \cdot (1 - 0.00174)^{(t - 2004)}\right) \; [kg]
     $$
 
-    ![Weight Approximation](../_static/reduced_order_sacchi_weight.svg)
+    <img alt="Weight Approximation" src="../_static/reduced_order_sacchi_weight.svg">
 
     Notes
     -----
@@ -408,7 +408,7 @@ class yanto_etal:
     r"""
     This class implements the the reduced-order fuel burn model of Yanto and Liem (2017):
 
-    ![Payload/Range Diagram](../_static/reduced_order_yanto_etal.svg)
+    <img alt="Payload/Range Diagram" src="../_static/reduced_order_yanto_etal.svg">
 
     In this model, fuel burn calculations are based on a regression model.
     The regression coefficients were obtained by fitting mission parameters to fuel burn data obtained
@@ -581,7 +581,7 @@ class lee_etal:
     """
     This class implements the the reduced-order fuel burn model of Lee et al. (2010).
 
-    ![Payload/Range Diagram](../_static/reduced_order_lee_etal.svg)
+    <img alt="Payload/Range Diagram" src="../_static/reduced_order_lee_etal.svg">
 
     In this model, fuel burn calculations are based on a regression model.
     The regression coefficients were obtained by fitting mission parameters to fuel burn data obtained
@@ -989,7 +989,7 @@ class seymour_etal:
     r"""
     Reduced-order fuel burn model based on Seymour et al. (2020).
 
-    ![Payload/Range Diagram](../_static/reduced_order_seymour_etal.svg)
+    <img alt="Payload/Range Diagram" src="../_static/reduced_order_seymour_etal.svg">
 
     In this model, fuel burn calculations are based on a regression model.
     The regression coefficients were obtained by fitting mission parameters to fuel burn data obtained
@@ -1803,7 +1803,7 @@ class aim2015:
 
     The class implements the reduced-order fuel burn model of the [AIM2015 air transport model](https://www.atslab.org/data-tools/) (part "Aircraft Performance Model"):
 
-    ![Payload/Range Diagram](../_static/reduced_order_aim2015.svg)
+    <img alt="Payload/Range Diagram" src="../_static/reduced_order_aim2015.svg">
 
     In this model, fuel burn calculations are based on a regression model.
     The regression coefficients were obtained by fitting mission parameters to fuel burn data obtained
@@ -2065,7 +2065,7 @@ class eea_emission_inventory_2009:
     r"""
     The class implements the reduced-order fuel burn model of the [EMEP/EEA air pollutant emission inventory guidebook](https://www.eea.europa.eu/en/analysis/publications/emep-eea-guidebook-2023) (2009).
 
-    ![Payload/Range Diagram](../_static/reduced_order_eea2009.svg)
+    <img alt="Payload/Range Diagram" src="../_static/reduced_order_eea2009.svg">
 
     In this model, fuel burn calculations are based on a regression model.
     The regression coefficients were obtained by fitting mission parameters to fuel burn data obtained
@@ -2088,7 +2088,7 @@ class eea_emission_inventory_2009:
     Notes
     -----
     Data on military and transport aircraft from the sub-table `1.A.3.a Aviation vs2.3spreadsheet2-1updated2007.xlsx`
-    [used with permission](../_static/permissions/opensky_network_data_access_confirmation.pdf)
+    <a href="../_static/permissions/opensky_network_data_access_confirmation.pdf">used with permission</a>
     by the Swedish Defence Research Agency (foi.se). Note that this data may be a poor representation of
     newer variants of the same aircraft types.
 

--- a/src/jetfuelburn/utility/engines.py
+++ b/src/jetfuelburn/utility/engines.py
@@ -52,7 +52,7 @@ def calculate_corrected_tsfc(
     Trust-specific fuel consumption is a complex function of many parameters,
     and generally dependent on engine thrust as well as the Mach number:
 
-    ![TSFC vs Thrust](../_static/tsfc.svg)
+    <img alt="TSFC vs Thrust" src="../_static/tsfc.svg">
 
     The correction formula implemented in this function is a simplified empirical model
     which considers only variations in Mach number and atmospheric temperature, not thrust.
@@ -103,7 +103,7 @@ def calculate_corrected_tsfc(
     Engine performance charts often report TSFC at specific conditions.
     Consider, for example, this excerpt from the JT15D-1 engine datasheet:
 
-    ![Engine Datasheet](https://marien.sdsu.edu/Class_Materials/jt15d-engine.pdf){ type=application/pdf style="min-height:50vh;width:100%" }
+    <object type="application/pdf" data="https://marien.sdsu.edu/Class_Materials/jt15d-engine.pdf" style="min-height:50vh;width:100%"><a href="https://marien.sdsu.edu/Class_Materials/jt15d-engine.pdf">JT15D engine datasheet (PDF)</a></object>
 
     ```pyodide install='jetfuelburn'
     from jetfuelburn import ureg

--- a/src/jetfuelburn/utility/mathematics.py
+++ b/src/jetfuelburn/utility/mathematics.py
@@ -9,7 +9,7 @@ def _interpolate(
     r"""
     Given two sorted lists of x/y-pairs, performs one-dimensional linear interpolation for a given x-value:
 
-    ![1d Interpolation](../_static/interpolation.svg)
+    <img alt="1d Interpolation" src="../_static/interpolation.svg">
 
     The interpolation is performed using the formula:
 

--- a/src/jetfuelburn/utility/ofp.py
+++ b/src/jetfuelburn/utility/ofp.py
@@ -253,7 +253,7 @@ def generate_4d_trajectory(
       descent rate at the current altitude; as the aircraft descends through multiple regimes
       the rate is re-evaluated at each time step.
 
-    ![Flight Plan Diagram](../_static/ofp_1.svg)
+    <img alt="Flight Plan Diagram" src="../_static/ofp_1.svg">
 
     **Figure 1:** Diagrammatic representation of the `leveloff` strategy.
     Shown are two different _climb regimes_, which describe the altitude-dependent


### PR DESCRIPTION
All SVG figures rendered from docstrings (payload/range diagrams, reduced-order visual abstracts, TSFC plot, interpolation and flight-plan diagrams — 13 images across 5 API pages), the OpenSky permissions PDF link, and the JT15D datasheet embed are broken on the deployed site since the Zensical migration (#81).

### Root cause 1: relative paths from docstrings are rewritten twice
mkdocstrings renders docstring markdown with Zensical's `zrelpath` path processor cloned into its inner renderer, which correctly turns `../_static/x.svg` (relative to the hosting docs page) into `../../_static/x.svg`. Zensical then post-processes all stashed raw-HTML blocks of the outer page — which is how mkdocstrings output is injected — and applies the same directory-URL prefix a second time, producing `../../../_static/x.svg`. At a domain root browsers clamp the extra `../` and nothing looks wrong; under Read the Docs' `/en/latest/` prefix it escapes the version root and 404s. (Verified against a pre-migration MkDocs build, which emits the correct depth from identical docstrings; the double rewrite was confirmed with an instrumented build and appears to be unreported upstream — will be filed against Zensical.)

**Workaround here:** raw HTML in docstrings passes through the inner renderer untouched and is rewritten exactly once by the outer postprocessor, coming out correct — so markdown image/link syntax becomes plain `<img>`/`<a>` tags with unchanged, still page-relative paths. Revisit once the upstream fix lands.

### Root cause 2: the datasheet embed relied on mkdocs-pdf
`engines.py` embedded the JT15D datasheet with mkdocs-pdf's image syntax (`{ type=application/pdf }`); that plugin was dropped in #81 (Zensical does not support it), leaving a broken `<img>` pointing at a PDF. Replaced with a plain `<object type="application/pdf">` plus a fallback link — no plugin needed under either engine.

### Verification
Local `zensical build`: all five affected API pages emit `../../_static/...`, the permissions link resolves within the site root, the `<object>` embed is present, and no `../../../_static` remains anywhere in the built site.